### PR TITLE
Fix for bit ordering of li, vn, and mode

### DIFF
--- a/source/c/main.c
+++ b/source/c/main.c
@@ -47,9 +47,9 @@ int main( int argc, char* argv[ ] )
   typedef struct
   {
 
-    unsigned li   : 2;       // Only two bits. Leap indicator.
-    unsigned vn   : 3;       // Only three bits. Version number of the protocol.
     unsigned mode : 3;       // Only three bits. Mode. Client will pick mode 3 for client.
+    unsigned vn   : 3;       // Only three bits. Version number of the protocol.
+    unsigned li   : 2;       // Only two bits. Leap indicator.
 
     uint8_t stratum;         // Eight bits. Stratum level of the local clock.
     uint8_t poll;            // Eight bits. Maximum interval between successive messages.


### PR DESCRIPTION
The original bit order was wrong for the first byte of the NTP packet.  For example, settings ntp[0] = 0x1C, results in li = 0, vn = 7, mode = 0.  The correct answers are li = 0, vn = 3, mode = 4.

Here's a screenshot of the visual studio debugger showing the issue.
![image](https://user-images.githubusercontent.com/3163980/31822617-6564dd9c-b577-11e7-9e47-ae41725278c3.png)
